### PR TITLE
Rename master to main in CI

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -2,7 +2,7 @@ name: ci/cd
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
Rename master to main in CI release workflow.
